### PR TITLE
Autoinstall PyYAML module with INSTALL.SH

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -111,6 +111,12 @@ if ! echo $PATH | grep $bin_dir &> /dev/null; then
     echo $new_path >> ~/.bashrc
 fi
 
+if ! pip freeze | grep --silent PyYAML; then
+    echo "Installing PyYAML module"
+    pip install PyYAML --quiet
+    ok "Python modules installed successfully"
+fi
+
 ok "Pycritty installed successfully. Open a new terminal to test it!"
 
 if [[ $1 != 'fonts' ]]; then


### PR DESCRIPTION
Fix this error using the autoinstaller :
```bash
ModuleNotFoundError: No module named 'yaml'
```
This fix Installs the yaml module if it's not installed yet.