### PR TITLE
Transition of the Configuration to a TOML format

### DIFF
--- a/pycritty/api/load.py
+++ b/pycritty/api/load.py
@@ -1,17 +1,17 @@
 from pycritty import PycrittyError
-from pycritty.io import log, yaml_io
+from pycritty.io import log, toml_io
 from pycritty.resources import saves_dir, config_file, ConfigFile
 
 
 def load_config(name: str):
-    file_to_load = ConfigFile(saves_dir.get_or_create(), name, ConfigFile.YAML)
+    file_to_load = ConfigFile(saves_dir.get_or_create(), name, ConfigFile.FILES)
     if not file_to_load.exists():
         raise PycrittyError(f'Config "{name}" not found')
 
-    conf = yaml_io.read(file_to_load)
+    conf = toml_io.read(file_to_load)
     if conf is None or len(conf) < 1:
         log.warn(f'"{file_to_load}" has no content')
     else:
-        yaml_io.write(conf, config_file)
+        toml_io.write(conf, config_file)
 
     log.ok(f'Config "{name}" applied')

--- a/pycritty/api/rm.py
+++ b/pycritty/api/rm.py
@@ -8,7 +8,7 @@ from pycritty.resources.resource import ConfigFile
 def remove(configs: List[str], from_themes=False, force=False):
     config_parent = themes_dir if from_themes else saves_dir
     for conf in configs:
-        file = ConfigFile(config_parent.path, conf, ConfigFile.YAML)
+        file = ConfigFile(config_parent.path, conf, ConfigFile.FILES)
         if not file.exists():
             log.warn(f'{conf} ->', log.Color.BOLD, file, log.Color.YELLOW, 'not found')
             continue

--- a/pycritty/api/save.py
+++ b/pycritty/api/save.py
@@ -1,7 +1,7 @@
 from typing import Union
 from pathlib import Path
 from pycritty import PycrittyError
-from pycritty.io import log, yaml_io
+from pycritty.io import log, toml_io
 from pycritty.resources import config_file, saves_dir, themes_dir
 from pycritty.resources.resource import ConfigFile
 
@@ -13,17 +13,17 @@ def save_config(
     override=False,
 ):
     read_from = read_from or config_file
-    dest_file = ConfigFile(dest_parent.get_or_create(), name, ConfigFile.YAML)
+    dest_file = ConfigFile(dest_parent.get_or_create(), name, ConfigFile.FILES)
     word_to_use = "Theme" if dest_parent == themes_dir else "Config"
     if dest_file.exists() and not override:
         raise PycrittyError(
             f'{word_to_use} "{name}" already exists, use -o to override'
         )
 
-    conf = yaml_io.read(read_from)
+    conf = toml_io.read(read_from)
     if conf is None or len(conf) < 1:
         log.warn(f'"{read_from}" has no content')
     else:
         dest_file.create()
-        yaml_io.write(conf, dest_file)
+        toml_io.write(conf, dest_file)
         log.ok(f"{word_to_use} saved =>", log.Color.BLUE, dest_file)

--- a/pycritty/io/error.py
+++ b/pycritty/io/error.py
@@ -1,0 +1,9 @@
+from pycritty import PycrittyError
+
+
+class FileIOError(PycrittyError):
+    pass
+
+
+class FileParseError(PycrittyError):
+    pass

--- a/pycritty/io/toml_io.py
+++ b/pycritty/io/toml_io.py
@@ -1,0 +1,43 @@
+from io import BufferedRandom
+from pathlib import Path
+from typing import Dict, Any, Union, Callable
+from urllib.error import URLError
+from urllib.parse import urlparse
+from urllib.request import urlopen
+
+import toml
+
+from pycritty.io.error import FileIOError, FileParseError
+from pycritty.resources.resource import Resource
+
+
+def write(y: Dict[str, Any], file: Union[Path, Resource]):
+    if isinstance(file, Resource):
+        file = file.path
+    try:
+        with open(file, 'w') as f:
+            toml.dump(y, f)
+    except IOError as e:
+        raise FileIOError(f'Error trying to write "{file}":\n{e}')
+
+
+def read(url: Union[str, Path, Resource]) -> Dict[str, Any]:
+    has_protocol = False
+    open_function: Callable[..., BufferedRandom]
+
+    if isinstance(url, str):
+        has_protocol = urlparse(url).scheme != ''
+    if isinstance(url, Resource):
+        url = url.path
+    if not has_protocol or isinstance(url, Path):
+        open_function = open
+    else:
+        open_function = urlopen
+
+    try:
+        with open_function(url) as f:
+            return toml.load(f)
+    except (IOError, URLError) as e:
+        raise FileIOError(f'Error trying to access "{url}":\n{e}')
+    except (UnicodeDecodeError, toml.decoder.TomlDecodeError) as e:
+        raise FileParseError(f'Failed decoding "{url}":\n{e}')

--- a/pycritty/resources/__init__.py
+++ b/pycritty/resources/__init__.py
@@ -4,11 +4,11 @@ from pycritty.resources.resource import ConfigFile,  ConfigDir
 
 pycritty_dir = ConfigDir(Path().home() / '.config' / 'pycritty')
 alacritty_dir = ConfigDir(Path().home() / '.config' / 'alacritty')
-config_file = ConfigFile(alacritty_dir.path, 'alacritty', ConfigFile.YAML)
-fonts_file = ConfigFile(pycritty_dir.path, 'fonts', ConfigFile.YAML)
+config_file = ConfigFile(alacritty_dir.path, 'alacritty', ConfigFile.FILES)
+fonts_file = ConfigFile(pycritty_dir.path, 'fonts', ConfigFile.FILES)
 themes_dir = ConfigDir(pycritty_dir.path / 'themes')
 saves_dir = ConfigDir(pycritty_dir.path / 'saves')
 
 
 def get_theme(theme: str) -> ConfigFile:
-    return ConfigFile(themes_dir.get_or_create(), theme, ConfigFile.YAML)
+    return ConfigFile(themes_dir.get_or_create(), theme, ConfigFile.FILES)

--- a/pycritty/resources/resource.py
+++ b/pycritty/resources/resource.py
@@ -39,7 +39,7 @@ class ConfigDir(Resource):
 class ConfigFile(Resource):
     """Class used to manage config files that may have many possible extensions"""
 
-    YAML = ['yml', 'yaml']
+    FILES = ['toml', 'yml', 'yaml']
 
     def __init__(self, parent: Path, name: str, extensions: List[str]):
         if len(extensions) > 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ flake8==4.0.1
 mypy==0.931
 pytest==7.0.1
 PyYAML==6.0
+toml==0.10.2
 types-setuptools==57.4.9
 types-PyYAML==6.0.4

--- a/tests/cli/test_ls.py
+++ b/tests/cli/test_ls.py
@@ -10,7 +10,7 @@ class TestListFonts:
     def test_it_should_raise_pycritty_error_when_file_does_not_exist(self):
         target_file = Mock(
             spec=ConfigFile,
-            path=Path().cwd() / "example.yaml",
+            path=Path().cwd() / "example.toml",
             exists=Mock(return_value=False),
         )
 
@@ -18,36 +18,36 @@ class TestListFonts:
             list_fonts(target_file)
 
     @pytest.mark.parametrize("fonts_content", [None, {}])
-    @patch("pycritty.api.ls.yaml_io")
+    @patch("pycritty.api.ls.toml_io")
     def test_it_should_return_empty_fonts_when_file_has_no_content(
-        self, mock_yaml_io: MagicMock, fonts_content
+        self, mock_toml_io: MagicMock, fonts_content
     ):
         target_file = Mock(
             spec=ConfigFile,
-            path=Path().cwd() / "example.yaml",
+            path=Path().cwd() / "example.toml",
             exists=Mock(return_value=True),
         )
-        mock_yaml_io.read.return_value = fonts_content
+        mock_toml_io.read.return_value = fonts_content
 
         fonts = list_fonts(target_file)
 
-        mock_yaml_io.read.assert_called_once_with(target_file)
+        mock_toml_io.read.assert_called_once_with(target_file)
         assert list(fonts) == []
 
-    @patch("pycritty.api.ls.yaml_io")
-    def test_it_should_return_fonts(self, mock_yaml_io: MagicMock):
+    @patch("pycritty.api.ls.toml_io")
+    def test_it_should_return_fonts(self, mock_toml_io: MagicMock):
         target_file = Mock(
             spec=ConfigFile,
-            path=Path().cwd() / "example.yaml",
+            path=Path().cwd() / "example.toml",
             exists=Mock(return_value=True),
         )
-        mock_yaml_io.read.return_value = {
+        mock_toml_io.read.return_value = {
             "fonts": {"onedark": "OneDark", "cascadia": "Cascadia"}
         }
 
         fonts = list_fonts(target_file)
 
-        mock_yaml_io.read.assert_called_once_with(target_file)
+        mock_toml_io.read.assert_called_once_with(target_file)
         assert list(fonts) == ["onedark", "cascadia"]
 
 


### PR DESCRIPTION
## Transition of the Configuration to a TOML format

This Pull Request brings about changes in the Alacritty terminal configuration by transitioning from a YAML file to a TOML file format. The configuration, creation, modification, and updates are now exclusively handled in a `.TOML` file. Additionally, it extends support for themes, allowing them to be read from either a `.yaml` or `.toml` file.

## Changes Made

- Shifted the terminal configuration to a `.TOML` file for comprehensive management.
- Themes can now be sourced from both `.yaml` and `.toml` files.

## Screenshots 

[Screencast from 2024-01-31 11-36-34.webm](https://github.com/antoniosarosi/pycritty/assets/98408526/aae9e195-482f-40ed-8413-3b6f37e3cf25)


![image](https://github.com/antoniosarosi/pycritty/assets/98408526/e8165e31-bfb4-4615-ad85-b20ad4df9883)
